### PR TITLE
[design]: global css - 악센트 컬러 추가

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4,6 +4,8 @@
 @custom-variant dark (&:is(.dark *));
 
 :root {
+  /* Orange */
+  --org: #ff9354;
   /* Grey */
   --grey-light: #f2f2f2;
   --grey-light-hover: #ececec;
@@ -63,6 +65,9 @@
 }
 
 @theme inline {
+  /* Orange Color */
+  --color-orange-accent: var(--org);
+
   /* Grey Colors */
   --color-light: var(--grey-light);
   --color-light-hover: var(--grey-light-hover);


### PR DESCRIPTION
## 🛰️ Issue Number

> ex) #이슈번호, #이슈번호 
없음 

## 🪐 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
글로벌 css에 악센트 컬러 추가함

### 사용방법
``` orange-accent``` 로 사용하면 됩니다 
예시 
``` bg-orange-accent ```

## 📚 Reference

## ✅ Check List
- [ ] 악센트 컬러 추가 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Introduced an orange accent color to the global theme for a more cohesive visual identity.
  - Standardized accent styling by defining a reusable theme token for orange accents.
  - Minor visual tweaks may appear in areas using the accent color.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->